### PR TITLE
Install specific version of ElasticSearch (#31)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -55,7 +55,7 @@ suites:
               - elasticsearch
         elasticsearch.sls:
           elasticsearch:
-            major_version: 5
+            version: 5.*
             plugins:
               lang-python: lang-python
             jvm_opts:

--- a/elasticsearch/jvmopts.sls
+++ b/elasticsearch/jvmopts.sls
@@ -1,9 +1,9 @@
 include:
   - elasticsearch.service
 
-{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+{% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
-{%- if major_version == 5 %}
+{%- if elasticsearch.major_version == 5 %}
 {%- set jvm_opts = salt['pillar.get']('elasticsearch:jvm_opts') %}
 {%- if jvm_opts %}
 /etc/elasticsearch/jvm.options:

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -1,4 +1,4 @@
-{% set elasticsearch = salt['grains.filter_by']({
+{% set elasticsearch_map = salt['grains.filter_by']({
     'default': {
         'pkg': 'elasticsearch',
     },

--- a/elasticsearch/pkg.sls
+++ b/elasticsearch/pkg.sls
@@ -1,13 +1,14 @@
-{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
-
 include:
   - elasticsearch.repo
 
-{% from "elasticsearch/map.jinja" import elasticsearch with context %}
+{% from "elasticsearch/map.jinja" import elasticsearch_map with context %}
+{% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
 elasticsearch_pkg:
   pkg.installed:
-    - name: {{ elasticsearch.pkg }}
-    - version: {{ major_version }}.*
+    - name: {{ elasticsearch_map.pkg }}
+    {% if elasticsearch.version %}
+    - version: {{ elasticsearch.version }}
+    {% endif %}
     - require:
       - sls: elasticsearch.repo

--- a/elasticsearch/plugins.sls
+++ b/elasticsearch/plugins.sls
@@ -1,11 +1,10 @@
 include:
   - elasticsearch.pkg
 
-
-{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+{% from "elasticsearch/settings.sls" import elasticsearch with context %}
 {%- set plugins_pillar = salt['pillar.get']('elasticsearch:plugins', {}) %}
 
-{% if major_version == 5 %}
+{% if elasticsearch.major_version == 5 %}
   {%- set plugin_bin = 'elasticsearch-plugin' %}
 {% else %}
   {%- set plugin_bin = 'plugin' %}

--- a/elasticsearch/repo.sls
+++ b/elasticsearch/repo.sls
@@ -1,21 +1,21 @@
-{%- set major_version = salt['pillar.get']('elasticsearch:major_version', 2) %}
+{% from "elasticsearch/settings.sls" import elasticsearch with context %}
 
-{%- if major_version == 5 %}
+{%- if elasticsearch.major_version == 5 %}
   {%- set repo_url = 'https://artifacts.elastic.co/packages/5.x' %}
 {%- else %}
   {%- set repo_url = 'http://packages.elastic.co/elasticsearch/2.x' %}
 {%- endif %}
 
-{%- if major_version == 5 and grains['os_family'] == 'Debian' %}
+{%- if elasticsearch.major_version == 5 and grains['os_family'] == 'Debian' %}
 apt-transport-https:
   pkg.installed
 {%- endif %}
 
 elasticsearch_repo:
   pkgrepo.managed:
-    - humanname: Elasticsearch {{ major_version }}
+    - humanname: Elasticsearch {{ elasticsearch.major_version }}
 {%- if grains.get('os_family') == 'Debian' %}
-  {%- if major_version == 5 %}
+  {%- if elasticsearch.major_version == 5 %}
     - name: deb {{ repo_url }}/apt stable main
   {%- else %}
     - name: deb {{ repo_url }}/debian stable main
@@ -27,7 +27,7 @@ elasticsearch_repo:
     - clean_file: true
 {%- elif grains['os_family'] == 'RedHat' %}
     - name: elasticsearch
-  {%- if major_version == 5 %}
+  {%- if elasticsearch.major_version == 5 %}
     - baseurl: {{ repo_url }}/yum
   {%- else %}
     - baseurl: {{ repo_url }}/centos

--- a/elasticsearch/settings.sls
+++ b/elasticsearch/settings.sls
@@ -1,0 +1,31 @@
+# Previously states directly looked up elasticsearch:major_version.
+# Now giving elasticsearch:major_version higher precedence, but for those
+# with major_version set and version not set, continue to honor the
+# major_version setting. If the package is already installed, but the pillar
+# data isn't set default to looking up major_version from the package
+# manager.
+
+{% from "elasticsearch/map.jinja" import elasticsearch_map with context %}
+
+{% set version = salt['pillar.get']('elasticsearch:version') %}
+{% if version %}
+  {% set major_version = version[0] | int %}
+{% else %}
+  {% set pillar_major_version = salt['pillar.get']('elasticsearch:major_version') %}
+  {% if pillar_major_version %}
+    {% set major_version = pillar_major_version %}
+  {% else %}
+    {% set pkg_version = salt['pkg.version'](elasticsearch_map.pkg) %}
+    {% if pkg_version %}
+      {% set major_version = pkg_version[0] | int %}
+    {% else %}
+      {% set major_version = False %}
+    {% endif %}
+  {% endif %}
+{% endif %}
+
+{% set elasticsearch = {} %}
+{% do elasticsearch.update( { 
+                              'version': version,
+                              'major_version': major_version,
+                            } ) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,5 @@
 elasticsearch:
-  major_version: 2
+  version: 2.4.2-1
   config:
     cluster.name: my-application
     node.name: node2


### PR DESCRIPTION
ElasticSearch was mistakenly upgraded on one of the instances in my
cluster, which lead to problems. Luckily it only happened on QA.
This change allows us to pin specific versions of ES, avoiding that
problem.

The basic logic is....

If `version` pillar is set, strip out the `major_version` and set both
in the config map.  A specific package version is installed if
`version` is set... and we do lots of special things throughout the
formula if `major_version` is 5.

This should be compatible for those already using the formula even
though I'm deprecating the `major_version` pillar value.